### PR TITLE
Add basic login with user and admin roles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+@ampproject/
+@esbuild/

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import maplibregl from 'maplibre-gl';
 import MapboxDraw from '@mapbox/mapbox-gl-draw';
+import { useAuth } from './AuthContext.jsx';
 
 /*
  * Indoor routing application with admin tools.
@@ -399,6 +400,8 @@ function computeRoute(features, startId, endId) {
 }
 
 export default function App() {
+  const { user, logout } = useAuth();
+  const isAdmin = user?.role === 'admin';
   const mapRef = useRef(null);
   const drawRef = useRef(null);
   const routeAnimRef = useRef(null);
@@ -424,12 +427,17 @@ export default function App() {
   });
   const [drawingRect, setDrawingRect] = useState(false);
   const [userView, setUserView] = useState(() => {
+    if (!isAdmin) return true;
     try {
       return localStorage.getItem(STORAGE_KEYS.userView) === 'true';
     } catch (_) {
       return false;
     }
   });
+
+  useEffect(() => {
+    if (!isAdmin) setUserView(true);
+  }, [isAdmin]);
 
   // Persist simple UI state
   useEffect(() => {
@@ -1283,14 +1291,17 @@ export default function App() {
       <div id="map"></div>
       {/* Toggle button for switching between admin and user views */}
       <div id="mode-toggle">
+        {isAdmin && (
         <button
           className="btn btn-secondary"
           onClick={toggleUserView}
         >
           {userView ? 'Tryb administratora' : 'Podgląd użytkownika'}
         </button>
+        )}
+        <button className="btn btn-secondary" onClick={logout}>Wyloguj</button>
       </div>
-      {!userView && (
+      {!userView && isAdmin && (
       <div id="sidebar">
         <h2 className="sidebar-title">Panel administracyjny</h2>
         <div className="section">

--- a/src/AuthContext.jsx
+++ b/src/AuthContext.jsx
@@ -1,0 +1,39 @@
+import { createContext, useContext, useState } from 'react';
+
+const AuthContext = createContext(null);
+
+export function AuthProvider({ children }) {
+  const [user, setUser] = useState(() => {
+    try {
+      return JSON.parse(localStorage.getItem('auth')) || null;
+    } catch (_) {
+      return null;
+    }
+  });
+
+  const login = (role) => {
+    const auth = { role };
+    setUser(auth);
+    try {
+      localStorage.setItem('auth', JSON.stringify(auth));
+    } catch (_) {}
+  };
+
+  const logout = () => {
+    setUser(null);
+    try {
+      localStorage.removeItem('auth');
+    } catch (_) {}
+  };
+
+  return (
+    <AuthContext.Provider value={{ user, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+
+export function useAuth() {
+  return useContext(AuthContext);
+}
+

--- a/src/Login.jsx
+++ b/src/Login.jsx
@@ -1,0 +1,37 @@
+import { useState } from 'react';
+import { useAuth } from './AuthContext.jsx';
+
+export default function Login() {
+  const { login } = useAuth();
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    if (username === 'admin' && password === 'adminpass') {
+      login('admin');
+    } else if (username === 'user' && password === 'userpass') {
+      login('user');
+    } else {
+      alert('Invalid credentials');
+    }
+  };
+
+  return (
+    <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', maxWidth: '200px', margin: '2rem auto', gap: '0.5rem' }}>
+      <input
+        placeholder="Username"
+        value={username}
+        onChange={(e) => setUsername(e.target.value)}
+      />
+      <input
+        type="password"
+        placeholder="Password"
+        value={password}
+        onChange={(e) => setPassword(e.target.value)}
+      />
+      <button type="submit" className="btn btn-primary">Login</button>
+    </form>
+  );
+}
+

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,10 +1,20 @@
 import React from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App.jsx';
+import Login from './Login.jsx';
+import { AuthProvider, useAuth } from './AuthContext.jsx';
 
-// Create the React root and render the application. This entry point is
-// consumed by Vite during development and build, and ensures that the
-// App component is mounted into the element with the id of 'root'.
+function Root() {
+  const { user } = useAuth();
+  return user ? <App /> : <Login />;
+}
+
+// Create the React root and render the application.
 const container = document.getElementById('root');
 const root = createRoot(container);
-root.render(<App />);
+root.render(
+  <AuthProvider>
+    <Root />
+  </AuthProvider>
+);
+


### PR DESCRIPTION
## Summary
- implement AuthContext for storing user roles and login/logout
- add Login page for admin and user credentials
- gate application with AuthProvider and restrict admin panel; add logout button
- ignore node_modules and build tooling directories

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b6c87461148322b630190cf7615b30